### PR TITLE
Fix capitalization error in header files.

### DIFF
--- a/src/font_Arial.h
+++ b/src/font_Arial.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ArialBlack.h
+++ b/src/font_ArialBlack.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ArialBold.h
+++ b/src/font_ArialBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ArialBoldItalic.h
+++ b/src/font_ArialBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ArialItalic.h
+++ b/src/font_ArialItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_AwesomeF000.h
+++ b/src/font_AwesomeF000.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_AwesomeF080.h
+++ b/src/font_AwesomeF080.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_AwesomeF100.h
+++ b/src/font_AwesomeF100.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_AwesomeF180.h
+++ b/src/font_AwesomeF180.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_AwesomeF200.h
+++ b/src/font_AwesomeF200.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ChanceryItalic.h
+++ b/src/font_ChanceryItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ComicSansMS.h
+++ b/src/font_ComicSansMS.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_ComicSansMSBold.h
+++ b/src/font_ComicSansMSBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_CourierNew.h
+++ b/src/font_CourierNew.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_CourierNewBold.h
+++ b/src/font_CourierNewBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_CourierNewBoldItalic.h
+++ b/src/font_CourierNewBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_CourierNewItalic.h
+++ b/src/font_CourierNewItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_Crystal.h
+++ b/src/font_Crystal.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSans.h
+++ b/src/font_DroidSans.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSansMono.h
+++ b/src/font_DroidSansMono.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSans_Bold.h
+++ b/src/font_DroidSans_Bold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSerif_Bold.h
+++ b/src/font_DroidSerif_Bold.h
@@ -8,17 +8,15 @@
 #elif __has_include(<ILI9341_t3n.h>)
 	#include "ILI9341_t3n.h"
 #elif __has_include(<ILI9341_t3.h>)
-	#include "ili9341_t3.h"
+	#include "ILI9341_t3.h"
 #elif __has_include(<ST7735_t3.h>)
 	#include "ST7735_t3.h"
 #elif __has_include(<HX8357_t3n.h>)
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSerif_BoldItalic.h
+++ b/src/font_DroidSerif_BoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSerif_Italic.h
+++ b/src/font_DroidSerif_Italic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_DroidSerif_Regular.h
+++ b/src/font_DroidSerif_Regular.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_Georgia.h
+++ b/src/font_Georgia.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_GeorgiaBold.h
+++ b/src/font_GeorgiaBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_GeorgiaBoldItalic.h
+++ b/src/font_GeorgiaBoldItalic.h
@@ -13,8 +13,8 @@
 	#include "ST7735_t3.h"
 #elif __has_include(<HX8357_t3n.h>)
 	#include "HX8357_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
+#elif __has_include(<GC9A01A_t3n.h>)
+	#include "GC9A01A_t3n.h"
 #else
 	#include "def_ili9341_fonts.h"
 #endif

--- a/src/font_GeorgiaItalic.h
+++ b/src/font_GeorgiaItalic.h
@@ -15,11 +15,10 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/font_Impact.h
+++ b/src/font_Impact.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationMono.h
+++ b/src/font_LiberationMono.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationMonoBold.h
+++ b/src/font_LiberationMonoBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 #ifdef __cplusplus
 extern "C" {

--- a/src/font_LiberationMonoBoldItalic.h
+++ b/src/font_LiberationMonoBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationMonoItalic.h
+++ b/src/font_LiberationMonoItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSans.h
+++ b/src/font_LiberationSans.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansBold.h
+++ b/src/font_LiberationSansBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansBoldItalic.h
+++ b/src/font_LiberationSansBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansItalic.h
+++ b/src/font_LiberationSansItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansNarrow.h
+++ b/src/font_LiberationSansNarrow.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansNarrowBold.h
+++ b/src/font_LiberationSansNarrowBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansNarrowBoldItalic.h
+++ b/src/font_LiberationSansNarrowBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSansNarrowItalic.h
+++ b/src/font_LiberationSansNarrowItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSerif.h
+++ b/src/font_LiberationSerif.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSerifBold.h
+++ b/src/font_LiberationSerifBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSerifBoldItalic.h
+++ b/src/font_LiberationSerifBoldItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_LiberationSerifItalic.h
+++ b/src/font_LiberationSerifItalic.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_Logisoso.h
+++ b/src/font_Logisoso.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_Michroma.h
+++ b/src/font_Michroma.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_Nunito.h
+++ b/src/font_Nunito.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus

--- a/src/font_NunitoBold.h
+++ b/src/font_NunitoBold.h
@@ -15,10 +15,8 @@
 	#include "HX8357_t3n.h"
 #elif __has_include(<GC9A01A_t3n.h>)
 	#include "GC9A01A_t3n.h"
-#elif __has_include(<ILI9341_GIGA_n.h>)
-	#include "ILI9341_GIGA_n.h"
 #else
-	#include "def_ili9341_fonts.h"
+	#include "def_ILI9341_fonts.h"
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
When compiling this library under Linux I was getting "file not found" errors. Tracked it down to:
`#else
	#include "def_ili9341_fonts.h"
#endif
`
Changed to:
`#else
	#include "def_ILI9341_fonts.h"
#endif
`
in all of the header files in the src directory. That's a lot of header files:) It probably compiled fine under Windows but Linux filenames are case sensitive. 